### PR TITLE
New analysis passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,20 +178,20 @@ Goldilocks (defined over a 448-bit prime field). However, since there are no con
 
 Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
 
-  | Template                  | Source file                        |
-  | ------------------------- | ---------------------------------- |
-  | `Sign`                    | `circuits/sign.circom`             |
-  | `AliasCheck`              | `circuits/aliascheck.circom`       |
-  | `CompConstant`            | `circuits/compconstant.circom`     |
-  | `Num2Bits_strict`         | `circuits/bitify.circom`           |
-  | `Bits2Num_strict`         | `circuits/bitify.circom`           |
-  | `Bits2Point_Strict`       | `circuits/bitify.circom`           |
-  | `Point2Bits_Strict`       | `circuits/bitify.circom`           |
-  | `SMTVerifier`             | `circuits/smt/smtverifier.circom`  |
-  | `SMTProcessor`            | `circuits/smt/smtprocessor.circom` |
-  | `EdDSAVerifier`           | `circuits/eddsa.circom`            |
-  | `EdDSAPoseidonVerifier`   | `circuits/eddsaposeidon.circom`    |
-  | `EdDSAMiMCSpongeVerifier` | `circuits/eddsamimcsponge.circom`  |
+  | Template                | Circomlib Source File            |
+  | ----------------------- | -------------------------------- |
+  | Sign                    | circuits/sign.circom             |
+  | AliasCheck              | circuits/aliascheck.circom       |
+  | CompConstant            | circuits/compconstant.circom     |
+  | Num2Bits_strict         | circuits/bitify.circom           |
+  | Bits2Num_strict         | circuits/bitify.circom           |
+  | Bits2Point_Strict       | circuits/bitify.circom           |
+  | Point2Bits_Strict       | circuits/bitify.circom           |
+  | SMTVerifier             | circuits/smt/smtverifier.circom  |
+  | SMTProcessor            | circuits/smt/smtprocessor.circom |
+  | EdDSAVerifier           | circuits/eddsa.circom            |
+  | EdDSAPoseidonVerifier   | circuits/eddsaposeidon.circom    |
+  | EdDSAMiMCSpongeVerifier | circuits/eddsamimcsponge.circom  |
 
 
 #### Overly complex functions or templates (Warning)

--- a/README.md
+++ b/README.md
@@ -178,20 +178,20 @@ Goldilocks (defined over a 448-bit prime field). However, since there are no con
 
 Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
 
-  | Template                | Circomlib Source File            |
-  | ----------------------- | -------------------------------- |
-  | Sign                    | circuits/sign.circom             |
-  | AliasCheck              | circuits/aliascheck.circom       |
-  | CompConstant            | circuits/compconstant.circom     |
-  | Num2Bits_strict         | circuits/bitify.circom           |
-  | Bits2Num_strict         | circuits/bitify.circom           |
-  | Bits2Point_Strict       | circuits/bitify.circom           |
-  | Point2Bits_Strict       | circuits/bitify.circom           |
-  | SMTVerifier             | circuits/smt/smtverifier.circom  |
-  | SMTProcessor            | circuits/smt/smtprocessor.circom |
-  | EdDSAVerifier           | circuits/eddsa.circom            |
-  | EdDSAPoseidonVerifier   | circuits/eddsaposeidon.circom    |
-  | EdDSAMiMCSpongeVerifier | circuits/eddsamimcsponge.circom  |
+  | Template                  | Circomlib Source File            |
+  | ------------------------- | -------------------------------- |
+  | `Sign`                    | circuits/sign.circom             |
+  | `AliasCheck`              | circuits/aliascheck.circom       |
+  | `CompConstant`            | circuits/compconstant.circom     |
+  | `Num2Bits_strict`         | circuits/bitify.circom           |
+  | `Bits2Num_strict`         | circuits/bitify.circom           |
+  | `Bits2Point_Strict`       | circuits/bitify.circom           |
+  | `Point2Bits_Strict`       | circuits/bitify.circom           |
+  | `SMTVerifier`             | circuits/smt/smtverifier.circom  |
+  | `SMTProcessor`            | circuits/smt/smtprocessor.circom |
+  | `EdDSAVerifier`           | circuits/eddsa.circom            |
+  | `EdDSAPoseidonVerifier`   | circuits/eddsaposeidon.circom    |
+  | `EdDSAMiMCSpongeVerifier` | circuits/eddsamimcsponge.circom  |
 
 
 #### Overly complex functions or templates (Warning)

--- a/README.md
+++ b/README.md
@@ -178,18 +178,20 @@ Goldilocks (defined over a 448-bit prime field). However, since there are no con
 
 Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
 
-  1.  `Sign` (defined in `circuits/sign.circom`)
-  2.  `AliasCheck` (defined in `circuits/aliascheck.circom`)
-  3.  `CompConstant` (defined in `circuits/compconstant.circom`)
-  4.  `Num2Bits_strict` (defined in `circuits/bitify.circom`)
-  5.  `Bits2Num_strict` (defined in `circuits/bitify.circom`)
-  6.  `Bits2Point_Strict` (defined in `circuits/bitify.circom`)
-  7.  `Point2Bits_Strict` (defined in `circuits/bitify.circom`)
-  8.  `SMTVerifier` (defined in `circuits/smt/smtverifier.circom`)
-  9.  `SMTProcessor` (defined in `circuits/smt/smtprocessor.circom`)
-  10. `EdDSAVerifier` (defined in `circuits/eddsa.circom`)
-  11. `EdDSAPoseidonVerifier` (defined in `circuits/eddsaposeidon.circom`)
-  12. `EdDSAMiMCSpongeVerifier` (defined in `circuits/eddsamimcsponge.circom`)
+  | Template                  | Source file                        |
+  | ------------------------- | ---------------------------------- |
+  | `Sign`                    | `circuits/sign.circom`             |
+  | `AliasCheck`              | `circuits/aliascheck.circom`       |
+  | `CompConstant`            | `circuits/compconstant.circom`     |
+  | `Num2Bits_strict`         | `circuits/bitify.circom`           |
+  | `Bits2Num_strict`         | `circuits/bitify.circom`           |
+  | `Bits2Point_Strict`       | `circuits/bitify.circom`           |
+  | `Point2Bits_Strict`       | `circuits/bitify.circom`           |
+  | `SMTVerifier`             | `circuits/smt/smtverifier.circom`  |
+  | `SMTProcessor`            | `circuits/smt/smtprocessor.circom` |
+  | `EdDSAVerifier`           | `circuits/eddsa.circom`            |
+  | `EdDSAPoseidonVerifier`   | `circuits/eddsaposeidon.circom`    |
+  | `EdDSAMiMCSpongeVerifier` | `circuits/eddsamimcsponge.circom`  |
 
 
 #### Overly complex functions or templates (Warning)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Clearly 512 is not less than 256, so we would expect `IsByte` to return 0. Howev
 Circomspect will check if the inputs to `LessThan` are constrained to the input size using `Num2Bits`. If it cannot prove that both inputs are constrained in this way, a warning is generated.
 
 
+#### Divisor in signal assignment not constrained to be non-zero (Warning)
+
+To ensure that a signal `c` is equal to `a / b` (where `b` is not constant), it is common to use a signal assignment to set `c <-- a / b` during witness generation, and then constrain `a`, `b`, and `c` to ensure that `c * b === a` during proof verification. However, the statement `c = a / b` only makes sense when `b` is not zero, whereas `c * b = a` may be true even when `b` is zero. For this reason it is important to also ensure that the divisor is non-zero when the proof is verified.
+
+Circomspect will identify signal assignments on the form `c <-- a / b` and ensure that the expression `b` is constrained to be non-zero using the Circomlib `IsZero` template. If no such constraint is found, a warning is emitted.
+
+
 #### Using BN128 specific templates together with custom primes (Warning)
 
 Circom defaults to using the BN128 curve (defined over a 254-bit prime field),

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Goldilocks (defined over a 448-bit prime field). However, since there are no con
 
 Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
 
-<center>
   | Template                  | Circomlib Source File            |
   | ------------------------- | -------------------------------- |
   | `Sign`                    | circuits/sign.circom             |
@@ -193,7 +192,7 @@ Circomlib templates that may be problematic when used together with curves other
   | `EdDSAVerifier`           | circuits/eddsa.circom            |
   | `EdDSAPoseidonVerifier`   | circuits/eddsaposeidon.circom    |
   | `EdDSAMiMCSpongeVerifier` | circuits/eddsamimcsponge.circom  |
-</center>
+
 
 #### Overly complex functions or templates (Warning)
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,28 @@ Clearly 512 is not less than 256, so we would expect `IsByte` to return 0. Howev
 Circomspect will check if the inputs to `LessThan` are constrained to the input size using `Num2Bits`. If it cannot prove that both inputs are constrained in this way, a warning is generated.
 
 
+#### Using BN128 specific templates together with custom primes (Warning)
+
+Circom defaults to using the BN128 curve (defined over a 254-bit prime field),
+but it also supports BSL12-381 (which is defined over a 381-bit field) and
+Goldilocks (defined over a 448-bit prime field). However, since there are no constants denoting either the prime or the prime size in bits available in the Circom language, some Circomlib templates like `Sign` (which returns the sign of the input signal), and `AliasCheck` (used by the strict versions of `Num2Bits` and `Bits2Num`), hardcode either the BN128 prime size or some other constant related to BN128. Using these circuits with a custom prime may thus lead to unexpected results and should be avoided.
+
+Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
+
+  1.  `Sign` (defined in `circuits/sign.circom`)
+  2.  `AliasCheck` (defined in `circuits/aliascheck.circom`)
+  3.  `CompConstant` (defined in `circuits/compconstant.circom`)
+  4.  `Num2Bits_strict` (defined in `circuits/bitify.circom`)
+  5.  `Bits2Num_strict` (defined in `circuits/bitify.circom`)
+  6.  `Bits2Point_Strict` (defined in `circuits/bitify.circom`)
+  7.  `Point2Bits_Strict` (defined in `circuits/bitify.circom`)
+  8.  `SMTVerifier` (defined in `circuits/smt/smtverifier.circom`)
+  9.  `SMTProcessor` (defined in `circuits/smt/smtprocessor.circom`)
+  10. `EdDSAVerifier` (defined in `circuits/eddsa.circom`)
+  11. `EdDSAPoseidonVerifier` (defined in `circuits/eddsaposeidon.circom`)
+  12. `EdDSAMiMCSpongeVerifier` (defined in `circuits/eddsamimcsponge.circom`)
+
+
 #### Overly complex functions or templates (Warning)
 
 As functions and templates grow in complexity they become more difficult to review and maintain. This typically indicates that the code should be refactored into smaller, more easily understandable, components. Circomspect uses cyclomatic complexity to estimate the complexity of each function and template, and will generate a warning if the code is considered too complex. Circomspect will also generate a warning if a function or template takes too many arguments, as this also impacts the readability of the code.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The Tornado Cash codebase was originally affected by an issue of this type. For 
 
 If a branching statement condition always evaluates to either `true` or `false`, this means that the branch is either always taken, or never taken. This typically indicates a mistake in the code which should be fixed.
 
+
 #### Use of the non-strict versions of `Num2Bits` and `Bits2Num` from Circomlib (Warning)
 
 Using `Num2Bits` and `Bits2Num` from
@@ -124,7 +125,42 @@ the prime. If not, there may be multiple correct representations of the input
 which could cause issues, since we typically expect the circuit output to be
 uniquely determined by the input.
 
-For example, Suppose that we create a component `n2b` given by `Num2Bits(254)` and set the input to `1`. Now, both the binary representation of `1` _and_ the representation of `p + 1` will satisfy the circuit over BN128, since both are 254-bit numbers. If you cannot restrict the input size below the prime size you should use the strict versions `Num2Bits_strict` and `Bits2Num_strict` to convert to and from binary representation. Circomspect will generate a warning if it cannot prove (using constant propagation) that the input size passed to `Num2Bits` or `Bits2Num` is less than the size of the prime in bits.
+For example, suppose that we create a component `n2b` given by `Num2Bits(254)` and set the input to `1`. Now, both the binary representation of `1` _and_ the representation of `p + 1` will satisfy the circuit over BN128, since both are 254-bit numbers. If you cannot restrict the input size below the prime size you should use the strict versions `Num2Bits_strict` and `Bits2Num_strict` to convert to and from binary representation. Circomspect will generate a warning if it cannot prove (using constant propagation) that the input size passed to `Num2Bits` or `Bits2Num` is less than the size of the prime in bits.
+
+
+#### Unconstrained input signals passed to `LessThan` from Circomlib (Warning)
+
+The Circomlib `LessThan` template takes an input size as argument. If the individual input signals are not constrained to the input size (for example using the Circomlib `Num2Bits` circuit), it is possible to find inputs `a` and `b` such that `a > b`, but `LessThan` still evaluates to true when given `a` and `b` as inputs.
+
+For example, consider the following template which takes a single input signal
+and attempts to constrain it to be less than 256.
+
+```js
+  template IsByte() {
+    signal input in;
+    signal output out;
+
+    component lt = LessThan(8);
+    lt.in[0] <== in;
+    lt.in[1] <== 256;
+
+    out <== lt.out;
+  }
+
+  component main = IsByte()
+```
+
+Suppose that we define the private input `in` as 512. This would result in the constraints
+
+```js
+    component lt = LessThan(8);
+    lt.in[0] <== 512;
+    lt.in[1] <== 256;
+```
+
+Clearly 512 is not less than 256, so we would expect `IsByte` to return 0. However, looking at [the implementation of `LessThan`](https://github.com/iden3/circomlib/blob/cff5ab6288b55ef23602221694a6a38a0239dcc0/circuits/comparators.circom#L89-L99), we see that `lt.out` is given by `1 - n2b.out[8] = 1 - (`bit `8` of `512 + 256 - 256) = 1 - 0 = 1`. It follows that 512 actually satisfies `IsByte()`, which is not what we wanted.
+
+Circomspect will check if the inputs to `LessThan` are constrained to the input size using `Num2Bits`. If it cannot prove that both inputs are constrained in this way, a warning is generated.
 
 
 #### Overly complex functions or templates (Warning)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Goldilocks (defined over a 448-bit prime field). However, since there are no con
 
 Circomlib templates that may be problematic when used together with curves other than BN128 include the following circuit definitions.
 
+<center>
   | Template                  | Circomlib Source File            |
   | ------------------------- | -------------------------------- |
   | `Sign`                    | circuits/sign.circom             |
@@ -192,7 +193,7 @@ Circomlib templates that may be problematic when used together with curves other
   | `EdDSAVerifier`           | circuits/eddsa.circom            |
   | `EdDSAPoseidonVerifier`   | circuits/eddsaposeidon.circom    |
   | `EdDSAMiMCSpongeVerifier` | circuits/eddsamimcsponge.circom  |
-
+</center>
 
 #### Overly complex functions or templates (Warning)
 

--- a/circom_algebra/src/modular_arithmetic.rs
+++ b/circom_algebra/src/modular_arithmetic.rs
@@ -79,7 +79,7 @@ pub fn complement_256(elem: &BigInt, field: &BigInt) -> BigInt {
         bit_repr.push(0);
     }
     for bit in &mut bit_repr {
-        *bit = if *bit == 0 { 1 } else { 0 };
+        *bit = u8::from(*bit == 0);
     }
     let cp = BigInt::from_radix_le(sign, &bit_repr, 2).unwrap();
     modulus(&cp, field)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,8 +52,11 @@ fn generate_cfg<Ast: IntoCfg>(
     ast: Ast,
     curve: &Curve,
     reports: &mut ReportCollection,
-) -> Result<Cfg, Report> {
-    ast.into_cfg(curve, reports).map_err(Report::from)?.into_ssa().map_err(Report::from)
+) -> Result<Cfg, Box<Report>> {
+    ast.into_cfg(curve, reports)
+        .map_err(|error| Box::new(Report::from(error)))?
+        .into_ssa()
+        .map_err(|error| Box::new(Report::from(error)))
 }
 
 fn analyze_cfg(cfg: &Cfg, reports: &mut ReportCollection) {
@@ -68,7 +71,7 @@ fn analyze_ast<Ast: IntoCfg>(ast: Ast, curve: &Curve, reports: &mut ReportCollec
             analyze_cfg(&cfg, reports);
         }
         Err(error) => {
-            reports.push(error);
+            reports.push(*error);
         }
     };
 }

--- a/parser/src/errors.rs
+++ b/parser/src/errors.rs
@@ -9,9 +9,9 @@ pub struct UnclosedCommentError {
 }
 
 impl UnclosedCommentError {
-    pub fn produce_report(error: Self) -> Report {
+    pub fn into_report(self) -> Report {
         let mut report = Report::error("Unterminated /* */.".to_string(), ReportCode::ParseFail);
-        report.add_primary(error.location, error.file_id, "Comment starts here.".to_string());
+        report.add_primary(self.location, self.file_id, "Comment starts here.".to_string());
         report
     }
 }
@@ -23,9 +23,9 @@ pub struct ParsingError {
 }
 
 impl ParsingError {
-    pub fn produce_report(error: Self) -> Report {
-        let mut report = Report::error(error.msg, ReportCode::ParseFail);
-        report.add_primary(error.location, error.file_id, "Invalid syntax".to_string());
+    pub fn into_report(self) -> Report {
+        let mut report = Report::error(self.msg, ReportCode::ParseFail);
+        report.add_primary(self.location, self.file_id, "Invalid syntax.".to_string());
         report
     }
 }
@@ -71,12 +71,12 @@ pub struct CompilerVersionError {
     pub version: Version,
 }
 impl CompilerVersionError {
-    pub fn produce_report(error: Self) -> Report {
+    pub fn into_report(self) -> Report {
         let message = format!(
             "The file `{}` requires version {}, which is not supported by circomspect (version {}).",
-            error.path,
-            version_string(&error.required_version),
-            version_string(&error.version),
+            self.path,
+            version_string(&self.required_version),
+            version_string(&self.version),
         );
         Report::error(message, ReportCode::CompilerVersionError)
     }

--- a/parser/src/include_logic.rs
+++ b/parser/src/include_logic.rs
@@ -48,7 +48,7 @@ impl FileStack {
         }
     }
 
-    pub fn add_include(&mut self, include: &Include) -> Result<(), Report> {
+    pub fn add_include(&mut self, include: &Include) -> Result<(), Box<Report>> {
         let mut location = self.current_location.clone().expect("parsing file");
         location.push(include.path.clone());
         match fs::canonicalize(location) {
@@ -58,12 +58,14 @@ impl FileStack {
                 }
                 Ok(())
             }
-            Err(_) => Err(IncludeError {
-                path: include.path.clone(),
-                file_id: include.meta.file_id,
-                file_location: include.meta.file_location(),
+            Err(_) => {
+                let error = IncludeError {
+                    path: include.path.clone(),
+                    file_id: include.meta.file_id,
+                    file_location: include.meta.file_location(),
+                };
+                Err(Box::new(error.into_report()))
             }
-            .into_report()),
         }
     }
 

--- a/program_analysis/src/bitwise_complement.rs
+++ b/program_analysis/src/bitwise_complement.rs
@@ -138,6 +138,13 @@ mod tests {
             }
         "#;
         validate_reports(src, 1);
+
+        let src = r#"
+            function f() {
+                return (1 > 2)? 3: 4;
+            }
+        "#;
+        validate_reports(src, 0);
     }
 
     fn validate_reports(src: &str, expected_len: usize) {

--- a/program_analysis/src/bn128_specific_circuit.rs
+++ b/program_analysis/src/bn128_specific_circuit.rs
@@ -53,7 +53,7 @@ pub fn find_bn128_specific_circuits(cfg: &Cfg) -> ReportCollection {
         // Exit early if we're using the default curve.
         return ReportCollection::new();
     }
-    debug!("running bn128-specific circuits analysis pass");
+    debug!("running bn128-specific circuit analysis pass");
     let mut reports = ReportCollection::new();
     for basic_block in cfg.iter() {
         for stmt in basic_block.iter() {

--- a/program_analysis/src/bn128_specific_circuit.rs
+++ b/program_analysis/src/bn128_specific_circuit.rs
@@ -1,0 +1,95 @@
+use log::debug;
+
+use program_structure::cfg::Cfg;
+use program_structure::constants::Curve;
+use program_structure::ir::{AssignOp, Expression, Meta, Statement};
+use program_structure::report::{Report, ReportCollection};
+use program_structure::report_code::ReportCode;
+use program_structure::file_definition::{FileLocation, FileID};
+
+const BN128_SPECIFIC_CIRCUITS: [&str; 12] = [
+    "Sign",
+    "AliasCheck",
+    "CompConstant",
+    "Num2Bits_strict",
+    "Bits2Num_strict",
+    "Bits2Point_Strict",
+    "Point2Bits_Strict",
+    "SMTVerifier",
+    "SMTProcessor",
+    "EdDSAVerifier",
+    "EdDSAPoseidonVerifier",
+    "EdDSAMiMCSpongeVerifier",
+];
+
+pub struct BN128SpecificCircuitWarning {
+    template_name: String,
+    file_id: Option<FileID>,
+    file_location: FileLocation,
+}
+
+impl BN128SpecificCircuitWarning {
+    pub fn into_report(self) -> Report {
+        let mut report = Report::warning(
+            format!(
+                "The `{}` template hard-codes BN128 specific parameters and should not be used with other curves.",
+                self.template_name
+            ),
+            ReportCode::BN128SpecificCircuit,
+        );
+        if let Some(file_id) = self.file_id {
+            report.add_primary(
+                self.file_location,
+                file_id,
+                format!("`{}` instantiated here.", self.template_name),
+            );
+        }
+        report
+    }
+}
+
+pub fn find_bn128_specific_circuits(cfg: &Cfg) -> ReportCollection {
+    if cfg.constants().curve() == &Curve::Bn128 {
+        // Exit early if we're using the default curve.
+        return ReportCollection::new();
+    }
+    debug!("running bn128-specific circuits analysis pass");
+    let mut reports = ReportCollection::new();
+    for basic_block in cfg.iter() {
+        for stmt in basic_block.iter() {
+            visit_statement(stmt, &mut reports);
+        }
+    }
+    debug!("{} new reports generated", reports.len());
+    reports
+}
+
+fn visit_statement(stmt: &Statement, reports: &mut ReportCollection) {
+    use AssignOp::*;
+    use Expression::*;
+    use Statement::*;
+    if let Substitution { meta: var_meta, op: AssignLocalOrComponent, rhe, .. } = stmt {
+        // If the variable `var` is declared as a local variable or signal, we exit early.
+        if var_meta.type_knowledge().is_local() || var_meta.type_knowledge().is_signal() {
+            return;
+        }
+        // If this is an update node, we extract the right-hand side.
+        let rhe = if let Update { rhe, .. } = rhe { rhe } else { rhe };
+
+        // A component initialization on the form `var = component_name(...)`.
+        if let Call { meta: component_meta, name: component_name, .. } = rhe {
+            if BN128_SPECIFIC_CIRCUITS.contains(&&component_name[..]) {
+                reports.push(build_report(component_meta, component_name));
+            }
+        }
+    }
+}
+
+fn build_report(meta: &Meta, name: &String) -> Report {
+    BN128SpecificCircuitWarning {
+        template_name: name.clone(),
+        file_id: meta.file_id,
+        file_location: meta.file_location(),
+    }
+    .into_report()
+}

--- a/program_analysis/src/bn128_specific_circuit.rs
+++ b/program_analysis/src/bn128_specific_circuit.rs
@@ -85,9 +85,9 @@ fn visit_statement(stmt: &Statement, reports: &mut ReportCollection) {
     }
 }
 
-fn build_report(meta: &Meta, name: &String) -> Report {
+fn build_report(meta: &Meta, name: &str) -> Report {
     BN128SpecificCircuitWarning {
-        template_name: name.clone(),
+        template_name: name.to_string(),
         file_id: meta.file_id,
         file_location: meta.file_location(),
     }

--- a/program_analysis/src/lib.rs
+++ b/program_analysis/src/lib.rs
@@ -8,6 +8,7 @@ pub mod taint_analysis;
 
 // Analysis passes.
 mod bitwise_complement;
+mod bn128_specific_circuit;
 mod constant_conditional;
 mod definition_complexity;
 mod field_arithmetic;
@@ -25,6 +26,7 @@ pub fn get_analysis_passes<'a>() -> Vec<Box<dyn Fn(&'a Cfg) -> ReportCollection 
         Box::new(side_effect_analysis::run_side_effect_analysis),
         Box::new(field_arithmetic::find_field_element_arithmetic),
         Box::new(field_comparisons::find_field_element_comparisons),
+        Box::new(bn128_specific_circuit::find_bn128_specific_circuits),
         Box::new(unconstrained_less_than::find_unconstrained_less_than),
         Box::new(constant_conditional::find_constant_conditional_statement),
         Box::new(nonstrict_binary_conversion::find_nonstrict_binary_conversion),

--- a/program_analysis/src/lib.rs
+++ b/program_analysis/src/lib.rs
@@ -15,6 +15,7 @@ mod field_arithmetic;
 mod field_comparisons;
 mod nonstrict_binary_conversion;
 mod unconstrained_less_than;
+mod unconstrained_division;
 mod side_effect_analysis;
 mod signal_assignments;
 
@@ -26,6 +27,7 @@ pub fn get_analysis_passes<'a>() -> Vec<Box<dyn Fn(&'a Cfg) -> ReportCollection 
         Box::new(side_effect_analysis::run_side_effect_analysis),
         Box::new(field_arithmetic::find_field_element_arithmetic),
         Box::new(field_comparisons::find_field_element_comparisons),
+        Box::new(unconstrained_division::find_unconstrained_division),
         Box::new(bn128_specific_circuit::find_bn128_specific_circuits),
         Box::new(unconstrained_less_than::find_unconstrained_less_than),
         Box::new(constant_conditional::find_constant_conditional_statement),

--- a/program_analysis/src/lib.rs
+++ b/program_analysis/src/lib.rs
@@ -13,6 +13,7 @@ mod definition_complexity;
 mod field_arithmetic;
 mod field_comparisons;
 mod nonstrict_binary_conversion;
+mod unconstrained_less_than;
 mod side_effect_analysis;
 mod signal_assignments;
 
@@ -24,6 +25,7 @@ pub fn get_analysis_passes<'a>() -> Vec<Box<dyn Fn(&'a Cfg) -> ReportCollection 
         Box::new(side_effect_analysis::run_side_effect_analysis),
         Box::new(field_arithmetic::find_field_element_arithmetic),
         Box::new(field_comparisons::find_field_element_comparisons),
+        Box::new(unconstrained_less_than::find_unconstrained_less_than),
         Box::new(constant_conditional::find_constant_conditional_statement),
         Box::new(nonstrict_binary_conversion::find_nonstrict_binary_conversion),
     ]

--- a/program_analysis/src/side_effect_analysis.rs
+++ b/program_analysis/src/side_effect_analysis.rs
@@ -276,14 +276,14 @@ pub fn run_side_effect_analysis(cfg: &Cfg) -> ReportCollection {
         })
         .cloned()
         .collect::<HashSet<_>>();
-    println!("exported signals: {exported_signals:?}");
+    // println!("exported signals: {exported_signals:?}");
 
     // Compute the set of variables tainted by input and output signals.
     let exported_sinks = exported_signals
         .iter()
         .flat_map(|source| taint_analysis.multi_step_taint(source))
         .collect::<HashSet<_>>();
-    println!("exported sinks: {exported_sinks:?}");
+    // println!("exported sinks: {exported_sinks:?}");
 
     // Collect variables constraining input and output sinks.
     let mut sinks = exported_sinks

--- a/program_analysis/src/signal_assignments.rs
+++ b/program_analysis/src/signal_assignments.rs
@@ -7,7 +7,6 @@ use program_structure::report_code::ReportCode;
 use program_structure::report::{Report, ReportCollection};
 use program_structure::ir::*;
 use program_structure::ir::AccessType;
-use program_structure::ir::degree_meta::Degree;
 use program_structure::ir::variable_meta::VariableMeta;
 
 pub struct SignalAssignmentWarning {
@@ -121,7 +120,7 @@ impl Assignment {
 
     fn is_quadratic(&self) -> bool {
         if let Some(range) = &self.degree {
-            range.end() <= Degree::Quadratic
+            range.is_quadratic()
         } else {
             false
         }

--- a/program_analysis/src/signal_assignments.rs
+++ b/program_analysis/src/signal_assignments.rs
@@ -71,7 +71,7 @@ impl UnecessarySignalAssignmentWarning {
     pub fn into_report(self) -> Report {
         let mut report = Report::warning(
             "Using the signal assignment operator `<--` is not necessary here.".to_string(),
-            ReportCode::UnecessarySignalAssignment,
+            ReportCode::UnnecessarySignalAssignment,
         );
         // Add signal assignment warning.
         if let Some(file_id) = self.assignment_meta.file_id {

--- a/program_analysis/src/taint_analysis.rs
+++ b/program_analysis/src/taint_analysis.rs
@@ -226,7 +226,7 @@ mod tests {
         );
         taint_map.insert("i", HashSet::from(["i".to_string(), "right".to_string()]));
 
-        validate_taint(&src, &taint_map);
+        validate_taint(src, &taint_map);
     }
 
     fn validate_taint(src: &str, taint_map: &HashMap<&str, HashSet<String>>) {

--- a/program_analysis/src/unconstrained_division.rs
+++ b/program_analysis/src/unconstrained_division.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use log::{debug, trace};
+
+use num_traits::Zero;
+use program_structure::cfg::Cfg;
+use program_structure::intermediate_representation::value_meta::{ValueReduction, ValueMeta};
+use program_structure::ir::degree_meta::DegreeMeta;
+use program_structure::report_code::ReportCode;
+use program_structure::report::{Report, ReportCollection};
+use program_structure::file_definition::{FileID, FileLocation};
+use program_structure::ir::*;
+
+pub struct UnconstrainedDivisionWarning {
+    divisor: Expression,
+    file_id: Option<FileID>,
+    file_location: FileLocation,
+}
+
+impl UnconstrainedDivisionWarning {
+    pub fn into_report(self) -> Report {
+        let mut report = Report::warning(
+            "In signal assignments containing division, the divisor needs to be constrained to be non-zero".to_string(),
+            ReportCode::UnconstrainedDivision,
+        );
+        if let Some(file_id) = self.file_id {
+            report.add_primary(
+                self.file_location,
+                file_id,
+                format!("The divisor `{}` must be constrained to be non-zero.", self.divisor),
+            );
+        }
+        report
+    }
+}
+
+#[derive(Eq, PartialEq, Hash)]
+struct VariableAccess {
+    pub var: VariableName,
+    pub access: Vec<AccessType>,
+}
+
+impl VariableAccess {
+    fn new(var: &VariableName, access: &[AccessType]) -> Self {
+        // We disregard the version to make sure accesses are not order dependent.
+        VariableAccess { var: var.without_version(), access: access.to_vec() }
+    }
+}
+
+/// Tracks `IsZero` template instantiations and uses.
+#[derive(Default)]
+struct Component {
+    pub input: Option<Expression>,
+    pub output: Option<Expression>,
+}
+
+impl Component {
+    fn new() -> Self {
+        Component::default()
+    }
+
+    fn ensures_nonzero(&self, expr: &Expression) -> bool {
+        if let Some(input) = self.input.as_ref() {
+            // This component ensures that the given expression is non-zero if
+            //   1. The component input is the given expression
+            //   2. The component output evaluates to false
+            expr == input && matches!(self.output(), Some(false))
+        } else {
+            false
+        }
+    }
+
+    fn output(&self) -> Option<bool> {
+        use ValueReduction::*;
+        let value = self.output.as_ref().and_then(|output| output.value());
+        match value {
+            Some(FieldElement { value }) => Some(!value.is_zero()),
+            Some(Boolean { value }) => Some(*value),
+            None => None,
+        }
+    }
+}
+
+/// Since division is not expressible as a quadratic constraint, it is common to
+/// perform division using the following pattern.
+///
+///   `c <-- a / b`
+///   `b * c === a`
+///
+/// That is, we assign the result of `a / b` to `c` during the proof generation,
+/// and the constrain `a`, `b`, and `c` to ensure that `b * c = a` during proof
+/// verification. However, this implicitly assumes that `b` is non-zero when the
+/// proof is generated, which needs to be verified separately when the proof is
+/// verified.
+///
+/// This analysis pass looks for signal assignments on the form `c <-- a / b`
+/// where the signal `b` is not constrained to be non-zero using the `IsZero`
+/// circuit from Circomlib.
+pub fn find_unconstrained_division(cfg: &Cfg) -> ReportCollection {
+    debug!("running unconstrained divisor analysis pass");
+    let mut reports = ReportCollection::new();
+    let mut divisors = Vec::new();
+    let mut constraints = HashMap::new();
+    for basic_block in cfg.iter() {
+        for stmt in basic_block.iter() {
+            update_divisors(stmt, &mut divisors);
+        }
+    }
+    if divisors.is_empty() {
+        return reports;
+    }
+
+    for basic_block in cfg.iter() {
+        for stmt in basic_block.iter() {
+            update_constraints(stmt, &mut constraints);
+        }
+    }
+    for divisor in divisors {
+        let mut non_zero = false;
+        for constraint in constraints.values() {
+            if constraint.ensures_nonzero(&divisor) {
+                non_zero = true;
+                break;
+            }
+        }
+        if !non_zero {
+            reports.push(build_report(&divisor));
+        }
+    }
+    debug!("{} new reports generated", reports.len());
+    reports
+}
+
+fn update_divisors(stmt: &Statement, divisors: &mut Vec<Expression>) {
+    use AssignOp::*;
+    use Statement::*;
+    use Expression::*;
+    use ExpressionInfixOpcode::*;
+    // Identify signal assignment on the form `c <-- a / b`.
+    if let Substitution { op: AssignSignal, rhe, .. } = stmt {
+        // If this is an update node, we extract the right-hand side.
+        let rhe = if let Update { rhe, .. } = rhe { rhe } else { rhe };
+
+        // If the assigned expression is on the form `a / b`, where `b` may be non-constant, we store the divisor `b`.
+        if let InfixOp { infix_op: Div, rhe, .. } = rhe {
+            match rhe.degree() {
+                Some(range) if !range.is_constant() => {
+                    divisors.push(*rhe.clone());
+                }
+                None => {
+                    divisors.push(*rhe.clone());
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn update_constraints(stmt: &Statement, constraints: &mut HashMap<VariableAccess, Component>) {
+    use AssignOp::*;
+    use Statement::*;
+    use Expression::*;
+    use AccessType::*;
+    match stmt {
+        // Identify `IsZero` template instantiations.
+        Substitution { meta, var, op: AssignLocalOrComponent, rhe } => {
+            // If the variable `var` is declared as a local variable or signal, we exit early.
+            if meta.type_knowledge().is_local() || meta.type_knowledge().is_signal() {
+                return;
+            }
+            // If this is an assignment on the form `var[i] = T(...)` we need to store the access and obtain the RHS.
+            let (rhe, access) = if let Update { access, rhe, .. } = rhe {
+                (rhe.as_ref(), access.clone())
+            } else {
+                (rhe, Vec::new())
+            };
+            if let Call { name: component_name, args, .. } = rhe {
+                if component_name == "IsZero" && args.is_empty() {
+                    // We assume this is the `IsZero` circuit from Circomlib.
+                    trace!(
+                        "`IsZero` template instantiation `{var}{}` found",
+                        vec_to_display(&access, "")
+                    );
+                    let component = VariableAccess::new(var, &access);
+                    constraints.insert(component, Component::new());
+                }
+            }
+        }
+        // Identify `IsZero` input signal assignments.
+        Substitution {
+            var, op: AssignConstraintSignal, rhe: Update { access, rhe, .. }, ..
+        } => {
+            // If this is a `Num2Bits` input signal assignment, the input signal
+            // access would be the last element of the `access` vector.
+            let mut component_access = access.clone();
+            let signal_access = component_access.pop();
+            let component = VariableAccess::new(var, &component_access);
+            if let Some(constraint) = constraints.get_mut(&component) {
+                // This is a signal assignment to either the input or output if `IsZero`.
+                if let Some(ComponentAccess(signal_name)) = signal_access {
+                    if signal_name == "in" {
+                        constraint.input = Some(*rhe.clone());
+                    }
+                }
+            }
+        }
+        // Identify `IsZero` output signal constraints on the form `var[i].out === expr`.
+        ConstraintEquality { lhe: Access { var, access, .. }, rhe, .. } => {
+            // Assume LHS is the `IsZero` output signal.
+            let mut component_access = access.clone();
+            let signal_access = component_access.pop();
+            let component = VariableAccess::new(var, &component_access);
+            if let Some(constraint) = constraints.get_mut(&component) {
+                if let Some(ComponentAccess(signal_name)) = signal_access {
+                    if signal_name == "out" {
+                        constraint.output = Some(rhe.clone());
+                    }
+                }
+            }
+        }
+        // Identify `IsZero` output signal constraints on the form `expr === var[i].out ===`.
+        ConstraintEquality { lhe, rhe: Access { var, access, .. }, .. } => {
+            // Assume RHS is the `IsZero` output signal.
+            let mut component_access = access.clone();
+            let signal_access = component_access.pop();
+            let component = VariableAccess::new(var, &component_access);
+            if let Some(constraint) = constraints.get_mut(&component) {
+                if let Some(ComponentAccess(signal_name)) = signal_access {
+                    if signal_name == "out" {
+                        constraint.output = Some(lhe.clone());
+                    }
+                }
+            }
+        }
+        // By default we do nothing.
+        _ => {}
+    }
+}
+
+#[must_use]
+fn build_report(divisor: &Expression) -> Report {
+    UnconstrainedDivisionWarning {
+        divisor: divisor.clone(),
+        file_id: divisor.meta().file_id,
+        file_location: divisor.meta().file_location(),
+    }
+    .into_report()
+}
+
+#[must_use]
+fn vec_to_display<T: fmt::Display>(elems: &[T], sep: &str) -> String {
+    elems.iter().map(|elem| format!("{elem}")).collect::<Vec<String>>().join(sep)
+}
+
+#[cfg(test)]
+mod tests {
+    use parser::parse_definition;
+    use program_structure::{cfg::IntoCfg, constants::Curve};
+
+    use super::*;
+
+    #[test]
+    fn test_unconstrained_less_than() {
+        let src = r#"
+            template Test(n) {
+              signal input a;
+              signal input b;
+              signal output c;
+
+              c <-- a / b;
+              c * b === a;
+            }
+        "#;
+        validate_reports(src, 1);
+
+        let src = r#"
+            template Test(n) {
+              signal input a[n];
+              signal input b[n];
+              signal output c[n];
+
+              for (var i = 0; i < n; i++) {
+                c[i] <-- a[i] / b[i];
+                c[i] * b[i] === a[i];
+              }
+            }
+        "#;
+        validate_reports(src, 1);
+
+        let src = r#"
+            template Test(n) {
+              signal input a;
+              signal input b;
+              signal output c;
+
+              component check = IsZero();
+              check.in <== b;
+              check.out === 1 - 1;
+
+              c <-- a / b;
+              c * b === a;
+            }
+        "#;
+        validate_reports(src, 0);
+
+        let src = r#"
+            template Test(n) {
+              signal input a;
+              signal input b;
+              signal output c;
+
+              c <-- a / b;
+              c * b === a;
+
+              component check = IsZero();
+              check.in <== b;
+              check.out === 0;
+            }
+        "#;
+        validate_reports(src, 0);
+
+        let src = r#"
+            template Test(n) {
+              signal input a;
+              signal input b;
+              signal output c;
+
+              component check = IsZero();
+              check.in <== b;
+              check.out === 1;
+
+              c <-- a / b;
+              c * b === a;
+            }
+        "#;
+        validate_reports(src, 1);
+
+        let src = r#"
+            template Test(n) {
+              signal input a;
+              signal input b;
+              signal output c;
+
+              component check = IsZero();
+              check.in <== a;
+              check.out === 0;
+
+              c <-- a / b;
+              c * b === a;
+            }
+        "#;
+        validate_reports(src, 1);
+    }
+
+    fn validate_reports(src: &str, expected_len: usize) {
+        // Build CFG.
+        let mut reports = ReportCollection::new();
+        let cfg = parse_definition(src)
+            .unwrap()
+            .into_cfg(&Curve::default(), &mut reports)
+            .unwrap()
+            .into_ssa()
+            .unwrap();
+        assert!(reports.is_empty());
+
+        // Generate report collection.
+        let reports = find_unconstrained_division(&cfg);
+        assert_eq!(reports.len(), expected_len);
+    }
+}

--- a/program_analysis/src/unconstrained_less_than.rs
+++ b/program_analysis/src/unconstrained_less_than.rs
@@ -331,7 +331,7 @@ mod tests {
               ok <== lt.out;
             }
         "#;
-        validate_reports(src, 1);
+        validate_reports(src, 2);
 
         let src = r#"
             template Test(n) {

--- a/program_analysis/src/unconstrained_less_than.rs
+++ b/program_analysis/src/unconstrained_less_than.rs
@@ -1,0 +1,392 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use log::{debug, trace};
+
+use program_structure::cfg::Cfg;
+use program_structure::report_code::ReportCode;
+use program_structure::report::{Report, ReportCollection};
+use program_structure::file_definition::{FileID, FileLocation};
+use program_structure::ir::*;
+
+pub struct UnconstrainedLessThanWarning {
+    input_size: Expression,
+    file_id: Option<FileID>,
+    primary_location: FileLocation,
+    secondary_location: FileLocation,
+}
+
+impl UnconstrainedLessThanWarning {
+    pub fn into_report(self) -> Report {
+        let mut report = Report::warning(
+            "Inputs to `LessThan` must be constrained to the input size".to_string(),
+            ReportCode::UnconstrainedLessThan,
+        );
+        if let Some(file_id) = self.file_id {
+            report.add_primary(
+                self.primary_location,
+                file_id,
+                format!(
+                    "This input to `LessThan` must be constrained to `{}` bits.",
+                    self.input_size
+                ),
+            );
+            report.add_secondary(
+                self.secondary_location,
+                file_id,
+                Some("Circomlib template `LessThan` instantiated here.".to_string()),
+            );
+        }
+        report
+    }
+}
+
+#[derive(Eq, PartialEq, Hash)]
+struct VariableAccess {
+    pub var: VariableName,
+    pub access: Vec<AccessType>,
+}
+
+impl VariableAccess {
+    fn new(var: &VariableName, access: &Vec<AccessType>) -> Self {
+        VariableAccess { var: var.clone(), access: access.clone() }
+    }
+}
+
+/// Tracks component instantiations `var = T(...)` where `T` is either `LessThan`
+/// or `Num2Bits`.
+enum Component {
+    LessThan { meta: Meta, required_size: Expression },
+    Num2Bits { enforced_size: Expression },
+}
+
+impl Component {
+    fn less_than(meta: &Meta, required_size: &Expression) -> Self {
+        Self::LessThan { meta: meta.clone(), required_size: required_size.clone() }
+    }
+
+    fn num_2_bits(enforced_size: &Expression) -> Self {
+        Self::Num2Bits { enforced_size: enforced_size.clone() }
+    }
+}
+
+/// Tracks component input signal initializations on the form `T.in <== input`
+/// where `T` is either `LessThan` or `Num2Bits`.
+enum ComponentInput {
+    LessThan {
+        component_meta: Meta,
+        input_meta: Meta,
+        value: Expression,
+        required_size: Expression,
+    },
+    Num2Bits {
+        value: Expression,
+        enforced_size: Expression,
+    },
+}
+
+impl ComponentInput {
+    fn less_than(
+        component_meta: &Meta,
+        input_meta: &Meta,
+        value: &Expression,
+        required_size: &Expression,
+    ) -> Self {
+        Self::LessThan {
+            component_meta: component_meta.clone(),
+            input_meta: input_meta.clone(),
+            value: value.clone(),
+            required_size: required_size.clone(),
+        }
+    }
+
+    fn num_2_bits(value: &Expression, enforced_size: &Expression) -> Self {
+        Self::Num2Bits { value: value.clone(), enforced_size: enforced_size.clone() }
+    }
+}
+
+// The signal input at `signal_meta` for the component defined at
+// `component_meta` must be at most `size` bits.
+struct SizeEntry {
+    pub component_meta: Meta,
+    pub input_meta: Meta,
+    pub required_size: Expression,
+}
+
+impl SizeEntry {
+    pub fn new(component_meta: &Meta, input_meta: &Meta, required_size: &Expression) -> Self {
+        SizeEntry {
+            component_meta: component_meta.clone(),
+            input_meta: input_meta.clone(),
+            required_size: required_size.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for SizeEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.required_size)
+    }
+}
+
+/// Size constraints for a single component input.
+#[derive(Debug, Default)]
+struct SizeConstraints {
+    /// Size constraint required by `LessThan`.
+    pub required: Vec<SizeEntry>,
+    /// Size constraint enforced by `Num2Bits`.
+    pub enforced: Vec<Expression>,
+}
+
+/// The `LessThan` template from Circomlib does not constrain the individual
+/// inputs to the input size `n`. If the input size can be more than `n` bits,
+/// it is possible to find field elements `a` and `b` such that
+///
+///   1. `a > b`,
+///   2. lt = LessThan(n),
+///   3. lt.in[0] = a,
+///   4. lt.in[1] = b, and
+///   5. lt.out = 1
+///
+/// This analysis pass looks for instantiations of `LessThan` where the inputs
+/// are not constrained to `n` bits using `Num2Bits`.
+pub fn find_unconstrained_less_than(cfg: &Cfg) -> ReportCollection {
+    debug!("running unconstrained less-than analysis pass");
+    let mut components = HashMap::new();
+    for basic_block in cfg.iter() {
+        for stmt in basic_block.iter() {
+            update_components(stmt, &mut components);
+        }
+    }
+    let mut inputs = Vec::new();
+    for basic_block in cfg.iter() {
+        for stmt in basic_block.iter() {
+            update_inputs(stmt, &components, &mut inputs);
+        }
+    }
+    let mut constraints = HashMap::<Expression, SizeConstraints>::new();
+    for input in inputs {
+        match input {
+            ComponentInput::LessThan { component_meta, input_meta, value, required_size } => {
+                constraints.entry(value.clone()).or_default().required.push(SizeEntry::new(
+                    &component_meta,
+                    &input_meta,
+                    &required_size,
+                ));
+            }
+            ComponentInput::Num2Bits { value, enforced_size, .. } => {
+                constraints.entry(value.clone()).or_default().enforced.push(enforced_size);
+            }
+        }
+    }
+
+    // Generate a report for each input to `LessThan` where the input size is
+    // not constrained to the `LessThan` bit size using `Num2Bits`.
+    let mut reports = ReportCollection::new();
+    for sizes in constraints.values() {
+        for required in &sizes.required {
+            if !sizes.enforced.contains(&required.required_size) {
+                reports.push(build_report(
+                    &required.component_meta,
+                    &required.input_meta,
+                    &required.required_size,
+                ))
+            }
+        }
+    }
+    debug!("{} new reports generated", reports.len());
+    reports
+}
+
+fn update_components(stmt: &Statement, components: &mut HashMap<VariableAccess, Component>) {
+    use AssignOp::*;
+    use Statement::*;
+    use Expression::*;
+    if let Substitution { meta, var, op: AssignLocalOrComponent, rhe, .. } = stmt {
+        // If the variable `var` is declared as a local variable or signal, we exit early.
+        if meta.type_knowledge().is_local() || meta.type_knowledge().is_signal() {
+            return;
+        }
+        // If this is an assignment on the form `var[i] = T(...)` we need to store the access and obtain the RHS.
+        let (rhe, access) = if let Update { access, rhe, .. } = rhe {
+            (rhe.as_ref(), access.clone())
+        } else {
+            (rhe, Vec::new())
+        };
+        if let Call { name: component_name, args, .. } = rhe {
+            if component_name == "LessThan" && args.len() == 1 {
+                // We assume this is the `LessThan` circuit from Circomlib.
+                trace!(
+                    "`LessThan` template instantiation `{var}{}` found",
+                    vec_to_display(&access, "")
+                );
+                let component = VariableAccess::new(var, &access);
+                components.insert(component, Component::less_than(meta, &args[0]));
+            } else if component_name == "Num2Bits" && args.len() == 1 {
+                // We assume this is the `Num2Bits` circuit from Circomlib.
+                trace!(
+                    "`LessThan` template instantiation `{var}{}` found",
+                    vec_to_display(&access, "")
+                );
+                let component = VariableAccess::new(var, &access);
+                components.insert(component, Component::num_2_bits(&args[0]));
+            }
+        }
+    }
+}
+
+fn update_inputs(
+    stmt: &Statement,
+    components: &HashMap<VariableAccess, Component>,
+    inputs: &mut Vec<ComponentInput>,
+) {
+    use AssignOp::*;
+    use Statement::*;
+    use Expression::*;
+    use AccessType::*;
+    if let Substitution {
+        var, op: AssignConstraintSignal, rhe: Update { access, rhe, .. }, ..
+    } = stmt
+    {
+        // If this is a `Num2Bits` input signal assignment, the input signal
+        // access would be the last element of the `access` vector.
+        let mut component_access = access.clone();
+        let signal_access = component_access.pop();
+        let component = VariableAccess::new(var, &component_access);
+        if let Some(Component::Num2Bits { enforced_size, .. }) = components.get(&component) {
+            let Some(ComponentAccess(signal_name)) = signal_access else {
+                return;
+            };
+            if signal_name != "in" {
+                return;
+            }
+            trace!("`Num2Bits` input signal assignment `{rhe}` found");
+            inputs.push(ComponentInput::num_2_bits(rhe, enforced_size));
+        }
+
+        // If this is a `LessThan` input signal assignment, the input index
+        // access would be the last element, and the input signal access
+        // would be the next to last element of the `access` vector.
+        let mut component_access = access.clone();
+        let index_access = component_access.pop();
+        let signal_access = component_access.pop();
+        let component = VariableAccess::new(var, &component_access);
+        if let Some(Component::LessThan { meta: component_meta, required_size, .. }) =
+            components.get(&component)
+        {
+            let (Some(ComponentAccess(signal_name)), Some(ArrayAccess(_))) = (signal_access, index_access) else {
+                return;
+            };
+            if signal_name != "in" {
+                return;
+            }
+            trace!("`LessThan` input signal assignment `{rhe}` found");
+            inputs.push(ComponentInput::less_than(component_meta, rhe.meta(), rhe, required_size));
+        }
+    }
+}
+
+#[must_use]
+fn build_report(component_meta: &Meta, input_meta: &Meta, size: &Expression) -> Report {
+    UnconstrainedLessThanWarning {
+        input_size: size.clone(),
+        file_id: component_meta.file_id,
+        primary_location: input_meta.file_location(),
+        secondary_location: component_meta.file_location(),
+    }
+    .into_report()
+}
+
+#[must_use]
+fn vec_to_display<T: fmt::Display>(elems: &[T], sep: &str) -> String {
+    elems.iter().map(|elem| format!("{elem}")).collect::<Vec<String>>().join(sep)
+}
+
+#[cfg(test)]
+mod tests {
+    use parser::parse_definition;
+    use program_structure::{cfg::IntoCfg, constants::Curve};
+
+    use super::*;
+
+    #[test]
+    fn test_unconstrained_less_than() {
+        let src = r#"
+            template Test(n) {
+              signal input small;
+              signal input large;
+              signal output ok;
+
+              // Check that small < large.
+              component lt = LessThan(n);
+              lt.in[0] <== small;
+              lt.in[1] <== large;
+
+              ok <== lt.out;
+            }
+        "#;
+        validate_reports(src, 1);
+
+        let src = r#"
+            template Test(n) {
+              signal input small;
+              signal input large;
+              signal output ok;
+
+              // Constrain inputs to n bits.
+              component n2b[2];
+              n2b[0] = Num2Bits(n);
+              n2b[0].in <== small;
+              n2b[1] = Num2Bits(n + 1);
+              n2b[1].in <== large;
+
+              // Check that small < large.
+              component lt = LessThan(n);
+              lt.in[0] <== small;
+              lt.in[1] <== large;
+
+              ok <== lt.out;
+            }
+        "#;
+        validate_reports(src, 1);
+
+        let src = r#"
+            template Test(n) {
+              signal input small;
+              signal input large;
+              signal output ok;
+
+              // Constrain inputs to n bits.
+              component n2b[2];
+              n2b[0] = Num2Bits(n);
+              n2b[0].in <== small;
+              n2b[1] = Num2Bits(n);
+              n2b[1].in <== large;
+
+              // Check that small < large.
+              component lt = LessThan(n);
+              lt.in[0] <== small;
+              lt.in[1] <== large;
+
+              ok <== lt.out;
+            }
+        "#;
+        validate_reports(src, 0);
+    }
+
+    fn validate_reports(src: &str, expected_len: usize) {
+        // Build CFG.
+        let mut reports = ReportCollection::new();
+        let cfg = parse_definition(src)
+            .unwrap()
+            .into_cfg(&Curve::default(), &mut reports)
+            .unwrap()
+            .into_ssa()
+            .unwrap();
+        assert!(reports.is_empty());
+
+        // Generate report collection.
+        let reports = find_unconstrained_less_than(&cfg);
+        assert_eq!(reports.len(), expected_len);
+    }
+}

--- a/program_analysis/src/unconstrained_less_than.rs
+++ b/program_analysis/src/unconstrained_less_than.rs
@@ -49,7 +49,8 @@ struct VariableAccess {
 
 impl VariableAccess {
     fn new(var: &VariableName, access: &[AccessType]) -> Self {
-        VariableAccess { var: var.clone(), access: access.to_vec() }
+        // We disregard the version to make sure accesses are not order dependent.
+        VariableAccess { var: var.without_version(), access: access.to_vec() }
     }
 }
 
@@ -373,6 +374,29 @@ mod tests {
               component lt = LessThan(n);
               lt.in[0] <== small;
               lt.in[1] <== large;
+
+              ok <== lt.out;
+            }
+        "#;
+        validate_reports(src, 0);
+
+        let src = r#"
+            template Test(n) {
+              signal input small;
+              signal input large;
+              signal output ok;
+
+              // Check that small < large.
+              component lt = LessThan(n);
+              lt.in[1] <== large;
+              lt.in[0] <== small;
+
+              // Constrain inputs to n bits.
+              component n2b[2];
+              n2b[0] = Num2Bits(n);
+              n2b[0].in <== small;
+              n2b[1] = Num2Bits(n);
+              n2b[1].in <== large;
 
               ok <== lt.out;
             }

--- a/program_structure/src/control_flow_graph/basic_block.rs
+++ b/program_structure/src/control_flow_graph/basic_block.rs
@@ -119,15 +119,8 @@ impl BasicBlock {
     pub fn propagate_degrees(&mut self, env: &mut DegreeEnvironment) -> bool {
         trace!("propagating degree ranges for basic block {}", self.index());
         let mut result = false;
-        let mut rerun = true;
-        while rerun {
-            // Rerun value propagation if a single child node was updated.
-            rerun = false;
-            for stmt in self.iter_mut() {
-                rerun = rerun || stmt.propagate_degrees(env);
-            }
-            // Return true if a single child node was updated.
-            result = result || rerun;
+        for stmt in self.iter_mut() {
+            result = result || stmt.propagate_degrees(env);
         }
         result
     }
@@ -135,15 +128,8 @@ impl BasicBlock {
     pub fn propagate_values(&mut self, env: &mut ValueEnvironment) -> bool {
         trace!("propagating values for basic block {}", self.index());
         let mut result = false;
-        let mut rerun = true;
-        while rerun {
-            // Rerun value propagation if a single child node was updated.
-            rerun = false;
-            for stmt in self.iter_mut() {
-                rerun = rerun || stmt.propagate_values(env);
-            }
-            // Return true if a single child node was updated.
-            result = result || rerun;
+        for stmt in self.iter_mut() {
+            result = result || stmt.propagate_values(env);
         }
         result
     }

--- a/program_structure/src/intermediate_representation/degree_meta.rs
+++ b/program_structure/src/intermediate_representation/degree_meta.rs
@@ -269,6 +269,24 @@ impl DegreeRange {
         self.start() <= degree && degree <= self.end()
     }
 
+    /// Returns true if the upper bound is at most constant.
+    #[must_use]
+    pub fn is_constant(&self) -> bool {
+        self.end() <= Degree::Constant
+    }
+
+    /// Returns true if the upper bound is at most linear.
+    #[must_use]
+    pub fn is_linear(&self) -> bool {
+        self.end() <= Degree::Linear
+    }
+
+    /// Returns true if the upper bound is at most quadratic.
+    #[must_use]
+    pub fn is_quadratic(&self) -> bool {
+        self.end() <= Degree::Quadratic
+    }
+
     /// Computes the infimum (under inverse inclusion) of `self` and `other`.
     /// Note, if the two ranges overlap this will simply be the union of `self`
     /// and `other`.
@@ -501,28 +519,34 @@ impl DegreeKnowledge {
         self.degree_range.as_ref()
     }
 
+    /// Returns true if the degree range is known, and the upper bound is
+    /// at most constant.
     #[must_use]
     pub fn is_constant(&self) -> bool {
         if let Some(range) = &self.degree_range {
-            range.end() <= Degree::Constant
+            range.is_constant()
         } else {
             false
         }
     }
 
+    /// Returns true if the degree range is known, and the upper bound is
+    /// at most linear.
     #[must_use]
     pub fn is_linear(&self) -> bool {
         if let Some(range) = &self.degree_range {
-            range.end() <= Degree::Linear
+            range.is_linear()
         } else {
             false
         }
     }
 
+    /// Returns true if the degree range is known, and the upper bound is
+    /// at most quadratic.
     #[must_use]
     pub fn is_quadratic(&self) -> bool {
         if let Some(range) = &self.degree_range {
-            range.end() <= Degree::Quadratic
+            range.is_quadratic()
         } else {
             false
         }

--- a/program_structure/src/intermediate_representation/degree_meta.rs
+++ b/program_structure/src/intermediate_representation/degree_meta.rs
@@ -537,32 +537,32 @@ mod tests {
     fn test_value_knowledge() {
         let mut value = DegreeKnowledge::new();
         assert!(value.degree().is_none());
-        assert_eq!(value.is_constant(), false);
-        assert_eq!(value.is_linear(), false);
-        assert_eq!(value.is_quadratic(), false);
+        assert!(!value.is_constant());
+        assert!(!value.is_linear());
+        assert!(!value.is_quadratic());
 
-        assert_eq!(value.set_degree(&Degree::Constant.into()), true);
+        assert!(value.set_degree(&Degree::Constant.into()));
         assert!(value.degree().is_some());
-        assert_eq!(value.is_constant(), true);
-        assert_eq!(value.is_linear(), true);
-        assert_eq!(value.is_quadratic(), true);
+        assert!(value.is_constant());
+        assert!(value.is_linear());
+        assert!(value.is_quadratic());
 
-        assert_eq!(value.set_degree(&Degree::Linear.into()), false);
+        assert!(!value.set_degree(&Degree::Linear.into()));
         assert!(value.degree().is_some());
-        assert_eq!(value.is_constant(), false);
-        assert_eq!(value.is_linear(), true);
-        assert_eq!(value.is_quadratic(), true);
+        assert!(!value.is_constant());
+        assert!(value.is_linear());
+        assert!(value.is_quadratic());
 
-        assert_eq!(value.set_degree(&Degree::Quadratic.into()), false);
+        assert!(!value.set_degree(&Degree::Quadratic.into()));
         assert!(value.degree().is_some());
-        assert_eq!(value.is_constant(), false);
-        assert_eq!(value.is_linear(), false);
-        assert_eq!(value.is_quadratic(), true);
+        assert!(!value.is_constant());
+        assert!(!value.is_linear());
+        assert!(value.is_quadratic());
 
-        assert_eq!(value.set_degree(&Degree::NonQuadratic.into()), false);
+        assert!(!value.set_degree(&Degree::NonQuadratic.into()));
         assert!(value.degree().is_some());
-        assert_eq!(value.is_constant(), false);
-        assert_eq!(value.is_linear(), false);
-        assert_eq!(value.is_quadratic(), false);
+        assert!(!value.is_constant());
+        assert!(!value.is_linear());
+        assert!(!value.is_quadratic());
     }
 }

--- a/program_structure/src/intermediate_representation/degree_meta.rs
+++ b/program_structure/src/intermediate_representation/degree_meta.rs
@@ -491,16 +491,78 @@ impl DegreeKnowledge {
     }
 
     pub fn set_degree(&mut self, range: &DegreeRange) -> bool {
-        if self.degree_range.is_none() {
-            self.degree_range = Some(range.clone());
-            true
+        let result = self.degree_range.is_none();
+        self.degree_range = Some(range.clone());
+        result
+    }
+
+    #[must_use]
+    pub fn degree(&self) -> Option<&DegreeRange> {
+        self.degree_range.as_ref()
+    }
+
+    #[must_use]
+    pub fn is_constant(&self) -> bool {
+        if let Some(range) = &self.degree_range {
+            range.end() <= Degree::Constant
         } else {
             false
         }
     }
 
     #[must_use]
-    pub fn degree(&self) -> Option<&DegreeRange> {
-        self.degree_range.as_ref()
+    pub fn is_linear(&self) -> bool {
+        if let Some(range) = &self.degree_range {
+            range.end() <= Degree::Linear
+        } else {
+            false
+        }
+    }
+
+    #[must_use]
+    pub fn is_quadratic(&self) -> bool {
+        if let Some(range) = &self.degree_range {
+            range.end() <= Degree::Quadratic
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Degree, DegreeKnowledge};
+
+    #[test]
+    fn test_value_knowledge() {
+        let mut value = DegreeKnowledge::new();
+        assert!(value.degree().is_none());
+        assert_eq!(value.is_constant(), false);
+        assert_eq!(value.is_linear(), false);
+        assert_eq!(value.is_quadratic(), false);
+
+        assert_eq!(value.set_degree(&Degree::Constant.into()), true);
+        assert!(value.degree().is_some());
+        assert_eq!(value.is_constant(), true);
+        assert_eq!(value.is_linear(), true);
+        assert_eq!(value.is_quadratic(), true);
+
+        assert_eq!(value.set_degree(&Degree::Linear.into()), false);
+        assert!(value.degree().is_some());
+        assert_eq!(value.is_constant(), false);
+        assert_eq!(value.is_linear(), true);
+        assert_eq!(value.is_quadratic(), true);
+
+        assert_eq!(value.set_degree(&Degree::Quadratic.into()), false);
+        assert!(value.degree().is_some());
+        assert_eq!(value.is_constant(), false);
+        assert_eq!(value.is_linear(), false);
+        assert_eq!(value.is_quadratic(), true);
+
+        assert_eq!(value.set_degree(&Degree::NonQuadratic.into()), false);
+        assert!(value.degree().is_some());
+        assert_eq!(value.is_constant(), false);
+        assert_eq!(value.is_linear(), false);
+        assert_eq!(value.is_quadratic(), false);
     }
 }

--- a/program_structure/src/intermediate_representation/expression_impl.rs
+++ b/program_structure/src/intermediate_representation/expression_impl.rs
@@ -968,6 +968,16 @@ impl fmt::Display for ExpressionPrefixOpcode {
     }
 }
 
+impl fmt::Debug for AccessType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        use AccessType::*;
+        match self {
+            ArrayAccess(index) => write!(f, "{index:?}"),
+            ComponentAccess(name) => write!(f, "{name:?}"),
+        }
+    }
+}
+
 impl fmt::Display for AccessType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         use AccessType::*;

--- a/program_structure/src/intermediate_representation/expression_impl.rs
+++ b/program_structure/src/intermediate_representation/expression_impl.rs
@@ -172,7 +172,7 @@ impl DegreeMeta for Expression {
                 let Some(range) = cond.degree() else {
                     return result;
                 };
-                if range.end() == Degree::Constant {
+                if range.is_constant() {
                     // The condition has constant degree.
                     if let Some(range) =
                         DegreeRange::iter_opt([if_true.degree(), if_false.degree()])
@@ -197,7 +197,7 @@ impl DegreeMeta for Expression {
                 // constant arguments the output must also be constant.
                 if args.iter().all(|arg| {
                     if let Some(range) = arg.degree() {
-                        matches!(range.end(), Constant)
+                        range.is_constant()
                     } else {
                         false
                     }

--- a/program_structure/src/intermediate_representation/expression_impl.rs
+++ b/program_structure/src/intermediate_representation/expression_impl.rs
@@ -536,21 +536,15 @@ impl ValueMeta for Expression {
         match self {
             InfixOp { meta, lhe, infix_op, rhe, .. } => {
                 let mut result = lhe.propagate_values(env) || rhe.propagate_values(env);
-                match infix_op.propagate_values(lhe.value(), rhe.value(), env) {
-                    Some(value) => {
-                        result = result || meta.value_knowledge_mut().set_reduces_to(value)
-                    }
-                    None => {}
+                if let Some(value) = infix_op.propagate_values(lhe.value(), rhe.value(), env) {
+                    result = result || meta.value_knowledge_mut().set_reduces_to(value)
                 }
                 result
             }
             PrefixOp { meta, prefix_op, rhe } => {
                 let mut result = rhe.propagate_values(env);
-                match prefix_op.propagate_values(rhe.value(), env) {
-                    Some(value) => {
-                        result = result || meta.value_knowledge_mut().set_reduces_to(value)
-                    }
-                    None => {}
+                if let Some(value) = prefix_op.propagate_values(rhe.value(), env) {
+                    result = result || meta.value_knowledge_mut().set_reduces_to(value)
                 }
                 result
             }

--- a/program_structure/src/intermediate_representation/statement_impl.rs
+++ b/program_structure/src/intermediate_representation/statement_impl.rs
@@ -86,6 +86,7 @@ impl Statement {
     #[must_use]
     pub fn propagate_values(&mut self, env: &mut ValueEnvironment) -> bool {
         use Statement::*;
+        use Expression::*;
         match self {
             Declaration { dimensions, .. } => {
                 let mut result = false;
@@ -95,12 +96,16 @@ impl Statement {
                 result
             }
             Substitution { meta, var, rhe, .. } => {
-                // TODO: Handle array values.
                 let mut result = rhe.propagate_values(env);
-                if let Some(value) = rhe.value() {
-                    env.add_variable(var, value);
-                    result = result || meta.value_knowledge_mut().set_reduces_to(value.clone());
+
+                // TODO: Handle array values.
+                if !matches!(rhe, Update { .. }) {
+                    if let Some(value) = rhe.value() {
+                        env.add_variable(var, value);
+                        result = result || meta.value_knowledge_mut().set_reduces_to(value.clone());
+                    }
                 }
+                trace!("Substitution returned {result}");
                 result
             }
             LogCall { args, .. } => {

--- a/program_structure/src/intermediate_representation/value_meta.rs
+++ b/program_structure/src/intermediate_representation/value_meta.rs
@@ -126,3 +126,31 @@ impl ValueKnowledge {
         matches!(self.reduces_to, Some(FieldElement { .. }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigInt;
+
+    use crate::ir::value_meta::ValueReduction;
+
+    use super::ValueKnowledge;
+
+    #[test]
+    fn test_value_knowledge() {
+        let mut value = ValueKnowledge::new();
+        assert!(matches!(value.get_reduces_to(), None));
+
+        assert_eq!(
+            value.set_reduces_to(ValueReduction::FieldElement { value: BigInt::from(1) }),
+            true
+        );
+        assert!(matches!(value.get_reduces_to(), Some(ValueReduction::FieldElement { .. })));
+        assert_eq!(value.is_field_element(), true);
+        assert_eq!(value.is_boolean(), false);
+
+        assert_eq!(value.set_reduces_to(ValueReduction::Boolean { value: true }), false);
+        assert!(matches!(value.get_reduces_to(), Some(ValueReduction::Boolean { .. })));
+        assert_eq!(value.is_field_element(), false);
+        assert_eq!(value.is_boolean(), true);
+    }
+}

--- a/program_structure/src/intermediate_representation/value_meta.rs
+++ b/program_structure/src/intermediate_representation/value_meta.rs
@@ -140,17 +140,16 @@ mod tests {
         let mut value = ValueKnowledge::new();
         assert!(matches!(value.get_reduces_to(), None));
 
-        assert_eq!(
-            value.set_reduces_to(ValueReduction::FieldElement { value: BigInt::from(1) }),
-            true
-        );
+        let number = ValueReduction::FieldElement { value: BigInt::from(1) };
+        assert!(value.set_reduces_to(number));
         assert!(matches!(value.get_reduces_to(), Some(ValueReduction::FieldElement { .. })));
-        assert_eq!(value.is_field_element(), true);
-        assert_eq!(value.is_boolean(), false);
+        assert!(value.is_field_element());
+        assert!(!value.is_boolean());
 
-        assert_eq!(value.set_reduces_to(ValueReduction::Boolean { value: true }), false);
+        let boolean = ValueReduction::Boolean { value: true };
+        assert!(!value.set_reduces_to(boolean));
         assert!(matches!(value.get_reduces_to(), Some(ValueReduction::Boolean { .. })));
-        assert_eq!(value.is_field_element(), false);
-        assert_eq!(value.is_boolean(), true);
+        assert!(!value.is_field_element());
+        assert!(value.is_boolean());
     }
 }

--- a/program_structure/src/program_library/report.rs
+++ b/program_structure/src/program_library/report.rs
@@ -71,6 +71,19 @@ impl FromStr for MessageCategory {
     }
 }
 
+impl MessageCategory {
+    /// Convert message category to Sarif level.
+    pub fn to_level(&self) -> String {
+        use MessageCategory::*;
+        match self {
+            Error => "error",
+            Warning => "warning",
+            Info => "note",
+        }
+        .to_string()
+    }
+}
+
 #[derive(Clone)]
 pub struct Report {
     category: MessageCategory,

--- a/program_structure/src/program_library/report_code.rs
+++ b/program_structure/src/program_library/report_code.rs
@@ -80,6 +80,7 @@ pub enum ReportCode {
     CyclomaticComplexity,
     TooManyArguments,
     UnconstrainedLessThan,
+    BN128SpecificCircuit,
 }
 
 impl ReportCode {
@@ -166,6 +167,7 @@ impl ReportCode {
             TooManyArguments => "CS0012",
             UnnecessarySignalAssignment => "CS0013",
             UnconstrainedLessThan => "CS0014",
+            BN128SpecificCircuit => "CS0015",
         }
         .to_string()
     }
@@ -251,6 +253,7 @@ impl ReportCode {
             CyclomaticComplexity => "cyclomatic-complexity",
             TooManyArguments => "too-many-arguments",
             UnconstrainedLessThan => "unconstrained-less-than",
+            BN128SpecificCircuit => "bn128-specific-circuit",
         }
         .to_string()
     }

--- a/program_structure/src/program_library/report_code.rs
+++ b/program_structure/src/program_library/report_code.rs
@@ -71,7 +71,7 @@ pub enum ReportCode {
     FieldElementComparison,
     FieldElementArithmetic,
     SignalAssignmentStatement,
-    UnecessarySignalAssignment,
+    UnnecessarySignalAssignment,
     UnusedVariableValue,
     UnusedParameterValue,
     VariableWithoutSideEffect,
@@ -163,7 +163,7 @@ impl ReportCode {
             NonStrictBinaryConversion => "CS0010",
             CyclomaticComplexity => "CS0011",
             TooManyArguments => "CS0012",
-            UnecessarySignalAssignment => "CS0013",
+            UnnecessarySignalAssignment => "CS0013",
         }
         .to_string()
     }
@@ -240,7 +240,7 @@ impl ReportCode {
             FieldElementComparison => "field-element-comparison",
             FieldElementArithmetic => "field-element-arithmetic",
             SignalAssignmentStatement => "signal-assignment-statement",
-            UnecessarySignalAssignment => "unecessary-signal-assignment",
+            UnnecessarySignalAssignment => "unnecessary-signal-assignment",
             UnusedVariableValue => "unused-variable-value",
             UnusedParameterValue => "unused-parameter-value",
             VariableWithoutSideEffect => "variable-without-side-effect",

--- a/program_structure/src/program_library/report_code.rs
+++ b/program_structure/src/program_library/report_code.rs
@@ -79,6 +79,7 @@ pub enum ReportCode {
     NonStrictBinaryConversion,
     CyclomaticComplexity,
     TooManyArguments,
+    UnconstrainedLessThan,
 }
 
 impl ReportCode {
@@ -164,6 +165,7 @@ impl ReportCode {
             CyclomaticComplexity => "CS0011",
             TooManyArguments => "CS0012",
             UnnecessarySignalAssignment => "CS0013",
+            UnconstrainedLessThan => "CS0014",
         }
         .to_string()
     }
@@ -248,6 +250,7 @@ impl ReportCode {
             NonStrictBinaryConversion => "non-strict-binary-conversion",
             CyclomaticComplexity => "cyclomatic-complexity",
             TooManyArguments => "too-many-arguments",
+            UnconstrainedLessThan => "unconstrained-less-than",
         }
         .to_string()
     }

--- a/program_structure/src/program_library/report_code.rs
+++ b/program_structure/src/program_library/report_code.rs
@@ -80,6 +80,7 @@ pub enum ReportCode {
     CyclomaticComplexity,
     TooManyArguments,
     UnconstrainedLessThan,
+    UnconstrainedDivision,
     BN128SpecificCircuit,
 }
 
@@ -167,7 +168,8 @@ impl ReportCode {
             TooManyArguments => "CS0012",
             UnnecessarySignalAssignment => "CS0013",
             UnconstrainedLessThan => "CS0014",
-            BN128SpecificCircuit => "CS0015",
+            UnconstrainedDivision => "CS0015",
+            BN128SpecificCircuit => "CS0016",
         }
         .to_string()
     }
@@ -253,6 +255,7 @@ impl ReportCode {
             CyclomaticComplexity => "cyclomatic-complexity",
             TooManyArguments => "too-many-arguments",
             UnconstrainedLessThan => "unconstrained-less-than",
+            UnconstrainedDivision => "unconstrained-division",
             BN128SpecificCircuit => "bn128-specific-circuit",
         }
         .to_string()

--- a/program_structure/src/static_single_assignment/dominator_tree.rs
+++ b/program_structure/src/static_single_assignment/dominator_tree.rs
@@ -34,7 +34,7 @@ impl<T: DirectedGraphNode> DominatorTree<T> {
         }
     }
 
-    pub fn get_entry_block(&self) -> Index {
+    pub fn entry_block(&self) -> Index {
         Index::default()
     }
 

--- a/program_structure/src/utils/constants.rs
+++ b/program_structure/src/utils/constants.rs
@@ -3,7 +3,7 @@ use num_bigint::BigInt;
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Curve {
     Bn128,
     Bls12_381,
@@ -65,12 +65,18 @@ impl FromStr for Curve {
 
 #[derive(Clone)]
 pub struct UsefulConstants {
+    curve: Curve,
     prime: BigInt,
 }
 
 impl UsefulConstants {
     pub fn new(curve: &Curve) -> UsefulConstants {
-        UsefulConstants { prime: curve.prime() }
+        UsefulConstants { curve: curve.clone(), prime: curve.prime() }
+    }
+
+    /// Returns the used curve.
+    pub fn curve(&self) -> &Curve {
+        &self.curve
     }
 
     /// Returns the used prime.

--- a/program_structure/src/utils/constants.rs
+++ b/program_structure/src/utils/constants.rs
@@ -53,12 +53,12 @@ impl Curve {
 impl FromStr for Curve {
     type Err = Error;
 
-    fn from_str(prime: &str) -> Result<Self, Self::Err> {
-        match &prime.to_uppercase()[..] {
+    fn from_str(curve: &str) -> Result<Self, Self::Err> {
+        match &curve.to_uppercase()[..] {
             "BN128" => Ok(Curve::Bn128),
             "BLS12_381" => Ok(Curve::Bls12_381),
             "GOLDILOCKS" => Ok(Curve::Goldilocks),
-            _ => Err(anyhow!("failed to parse prime `{prime}`")),
+            _ => Err(anyhow!("failed to parse curve `{curve}`")),
         }
     }
 }


### PR DESCRIPTION
This PR adds three new analysis passes.

  1. `unconstrained-less-than`: Identifies use of the Circomlib `LessThan` template where the inputs are not constrained to the input size.
  2. `unconstrained-division`: Identifies signal assignments on the form `c <-- a / b` where the expression `b` is not constrined to be non-zero.
  3. `bn128-specific-circuit`: Identifies use of Circomlib templates containing references to BN128-specific constants (either directly or indirectly), together with a custom curve like BLS12-381 or Goldilocks.