### PR TITLE
Reorder cyclomatic complexity calculation

### DIFF
--- a/program_analysis/src/definition_complexity.rs
+++ b/program_analysis/src/definition_complexity.rs
@@ -61,7 +61,7 @@ pub fn run_complexity_analysis(cfg: &Cfg) -> ReportCollection {
         edges += basic_block.successors().len();
         nodes += 1;
     }
-    let complexity = edges - nodes + 2;
+    let complexity = 2 + edges - nodes;
 
     let mut reports = ReportCollection::new();
     // Generate a report if the cyclomatic complexity is high.


### PR DESCRIPTION
When compiled in dev mode, circomspect panics with
``` 
thread 'main' panicked at 'attempt to subtract with overflow', program_analysis/src/definition_complexity.rs:65:22
```
when run on simple programs such as
 ```
 pragma circom 2.0.8;

template Example () {
    signal input a;
    signal output b;
    a <== b;
}

component main { public [ a ] } = Example();
```
because the number nodes (one) is greater than the number of edges (zero) and due to the ordering of operations the subtraction in `E - N + 2` underflows.
https://github.com/trailofbits/circomspect/blob/921cbb2aa80d1d67c81c7da761fe1aea347e4496/program_analysis/src/definition_complexity.rs#L64
This doesn't cause an issue in production builds since unsigned underflow is well-defined, but in dev builds it causes a panic.
