### PR TITLE
Introduced pub access-modifier for include_loggic module to expose FileStack from outside the library.

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -12,7 +12,7 @@ lalrpop_mod!(#[allow(clippy::all)] pub lang);
 use log::debug;
 
 mod errors;
-mod include_logic;
+pub mod include_logic;
 mod parser_logic;
 mod syntax_sugar_traits;
 mod syntax_sugar_remover;


### PR DESCRIPTION
Needed for calling parse_file which is now public and has FileStack as parameter. 